### PR TITLE
Add simple NPC collision dialogue

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,11 @@
         </div>
     </div>
 
+    <div id="arena">
+        <div class="npc" id="npcA"></div>
+        <div class="npc" id="npcB"></div>
+    </div>
+
     <div id="dialog">
         <p class="line" id="lineA"></p>
         <p class="line" id="lineB"></p>

--- a/script.js
+++ b/script.js
@@ -8,6 +8,20 @@ const profileLevels = [
   'chatty', 'outgoing', 'energetic', 'boisterous', 'wild', 'extreme'
 ];
 
+const profileSpeech = [
+  'barely mutters',
+  'speaks softly',
+  'says a few words',
+  'quietly responds',
+  'says plainly',
+  'chatters',
+  'talks openly',
+  'energetically says',
+  'shouts',
+  'yells wildly',
+  'exclaims loudly'
+];
+
 function getMoodText(value) {
   return moodLevels[value];
 }
@@ -18,8 +32,8 @@ function getProfileText(value) {
 
 function generateLine(name, moodVal, profileVal) {
   const mood = getMoodText(moodVal);
-  const profile = getProfileText(profileVal);
-  return `${name} feels ${mood} and ${profile}.`;
+  const speech = profileSpeech[profileVal];
+  return `${name} (${mood}) ${speech}.`;
 }
 
 function update() {
@@ -37,3 +51,51 @@ document.querySelectorAll('input[type=range]').forEach(el => {
 });
 
 update();
+
+// NPC movement and interaction
+const arena = document.getElementById('arena');
+const npcAEl = document.getElementById('npcA');
+const npcBEl = document.getElementById('npcB');
+
+const npcSize = 40;
+const arenaWidth = arena.clientWidth;
+const arenaHeight = arena.clientHeight;
+
+const npcA = { x: 50, y: 50, dx: 2, dy: 1.5 };
+const npcB = { x: 300, y: 200, dx: -2, dy: 2 };
+
+let lastTalk = 0;
+
+function moveNPC(npc, el) {
+  npc.x += npc.dx;
+  npc.y += npc.dy;
+
+  if (npc.x <= 0 || npc.x >= arenaWidth - npcSize) npc.dx *= -1;
+  if (npc.y <= 0 || npc.y >= arenaHeight - npcSize) npc.dy *= -1;
+
+  el.style.left = npc.x + 'px';
+  el.style.top = npc.y + 'px';
+}
+
+function areColliding(a, b) {
+  return !(
+    a.x + npcSize < b.x ||
+    a.x > b.x + npcSize ||
+    a.y + npcSize < b.y ||
+    a.y > b.y + npcSize
+  );
+}
+
+function talk() {
+  update();
+}
+
+setInterval(() => {
+  moveNPC(npcA, npcAEl);
+  moveNPC(npcB, npcBEl);
+
+  if (areColliding(npcA, npcB) && Date.now() - lastTalk > 2000) {
+    talk();
+    lastTalk = Date.now();
+  }
+}, 30);

--- a/style.css
+++ b/style.css
@@ -40,3 +40,26 @@ label {
 .line {
     margin: 5px 0;
 }
+
+#arena {
+    position: relative;
+    width: 800px;
+    height: 400px;
+    border: 4px solid #808080;
+    background: #202020;
+    margin-bottom: 20px;
+}
+
+.npc {
+    position: absolute;
+    width: 40px;
+    height: 40px;
+}
+
+#npcA {
+    background: #ff5555;
+}
+
+#npcB {
+    background: #55aaff;
+}


### PR DESCRIPTION
## Summary
- add arena with two moving NPC blocks
- style arena and NPCs
- generate lines based on mood and profile
- start simulation that triggers dialogue on collision

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68502e1d12348333a8f146690af663ae