### PR TITLE
Add basic NPC conversation overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,11 +32,10 @@
     <div id="arena">
         <div class="npc" id="npcA"></div>
         <div class="npc" id="npcB"></div>
-    </div>
-
-    <div id="dialog">
-        <p class="line" id="lineA"></p>
-        <p class="line" id="lineB"></p>
+        <div id="dialog">
+            <p class="line" id="lineA"></p>
+            <p class="line" id="lineB"></p>
+        </div>
     </div>
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -22,6 +22,20 @@ const profileSpeech = [
   'exclaims loudly'
 ];
 
+const moodDialog = [
+  'grumbles about the situation.',
+  'complains in an upset tone.',
+  'sighs gloomily.',
+  'responds with an uninterested "meh."',
+  'states things neutrally.',
+  'mentions everything is okay.',
+  'talks about feeling content.',
+  'cheerfully remarks about the day.',
+  'says how happy they are.',
+  'bubbles over with ecstatic energy.',
+  'speaks with hyper enthusiasm.'
+];
+
 function getMoodText(value) {
   return moodLevels[value];
 }
@@ -31,9 +45,9 @@ function getProfileText(value) {
 }
 
 function generateLine(name, moodVal, profileVal) {
-  const mood = getMoodText(moodVal);
   const speech = profileSpeech[profileVal];
-  return `${name} (${mood}) ${speech}.`;
+  const line = moodDialog[moodVal];
+  return `${name} ${speech}, "${line}"`;
 }
 
 function update() {
@@ -56,6 +70,7 @@ update();
 const arena = document.getElementById('arena');
 const npcAEl = document.getElementById('npcA');
 const npcBEl = document.getElementById('npcB');
+const dialogBox = document.getElementById('dialog');
 
 const npcSize = 40;
 const arenaWidth = arena.clientWidth;
@@ -88,6 +103,10 @@ function areColliding(a, b) {
 
 function talk() {
   update();
+  dialogBox.style.display = 'block';
+  setTimeout(() => {
+    dialogBox.style.display = 'none';
+  }, 1500);
 }
 
 setInterval(() => {

--- a/style.css
+++ b/style.css
@@ -32,9 +32,14 @@ label {
     background: #202020;
     border: 4px solid #808080;
     padding: 15px;
-    width: 100%;
-    max-width: 800px;
-    min-height: 100px;
+    width: 90%;
+    max-width: 760px;
+    min-height: 80px;
+    position: absolute;
+    left: 50%;
+    bottom: 10px;
+    transform: translateX(-50%);
+    display: none;
 }
 
 .line {


### PR DESCRIPTION
## Summary
- overlay conversation over the arena
- show dialog box only on collision
- generate mood-based conversation lines for each NPC

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685031404db48333b67bd89feb020eaa