### PR TITLE
Enhance glossary dropdown UI

### DIFF
--- a/glossary.css
+++ b/glossary.css
@@ -30,11 +30,27 @@ h1 {
   padding: 10px;
 }
 
+.term {
+  font-weight: bold;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .definition {
   display: none;
   margin-top: 5px;
+  font-weight: normal;
+  color: #333;
+}
+
+.icon {
+  margin-left: 8px;
 }
 
 .glossary-item.open .definition {
   display: block;
+  border-top: 1px solid #ccc;
+  padding-top: 5px;
 }

--- a/glossary.js
+++ b/glossary.js
@@ -9,9 +9,17 @@ function createItem(entry) {
   li.className = 'glossary-item';
 
   const term = document.createElement('div');
+  const icon = document.createElement('span');
+  icon.className = 'icon';
+  icon.textContent = '\u25B6'; // triangle pointing right
+
   term.textContent = entry.term;
+  term.appendChild(icon);
   term.className = 'term';
-  term.addEventListener('click', () => li.classList.toggle('open'));
+  term.addEventListener('click', () => {
+    li.classList.toggle('open');
+    icon.textContent = li.classList.contains('open') ? '\u25BC' : '\u25B6';
+  });
 
   const def = document.createElement('div');
   def.textContent = entry.definition;


### PR DESCRIPTION
## Summary
- add dropdown icons that flip open or closed
- make term/definition typography distinct
- show a dividing line when definitions are visible

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_685080db8c5c83339ec02b0ea84f3f69