### PR TITLE
Add categorized glossary

### DIFF
--- a/glossary.css
+++ b/glossary.css
@@ -23,14 +23,14 @@ h1 {
   margin: 0 auto;
 }
 
-.glossary-item {
-  background: #fff;
-  border: 1px solid #ccc;
-  margin-bottom: 5px;
-  padding: 10px;
+.category {
+  background: #e8e8e8;
+  border: 1px solid #888;
+  margin-bottom: 10px;
 }
 
-.term {
+.category-header {
+  padding: 10px;
   font-weight: bold;
   cursor: pointer;
   display: flex;
@@ -38,19 +38,43 @@ h1 {
   align-items: center;
 }
 
-.definition {
+.term-list {
+  list-style: none;
+  padding: 0 10px 10px 10px;
+  display: none;
+}
+
+.category.open .term-list {
+  display: block;
+}
+
+.term-item {
+  background: #fff;
+  border: 1px solid #ccc;
+  margin: 5px 0;
+  padding: 5px;
+}
+
+.term-header {
+  font-weight: bold;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.term-details {
   display: none;
   margin-top: 5px;
-  font-weight: normal;
   color: #333;
+}
+
+.term-item.open .term-details {
+  display: block;
+  border-top: 1px solid #ccc;
+  padding-top: 5px;
 }
 
 .icon {
   margin-left: 8px;
-}
-
-.glossary-item.open .definition {
-  display: block;
-  border-top: 1px solid #ccc;
-  padding-top: 5px;
 }

--- a/glossary.json
+++ b/glossary.json
@@ -1,318 +1,578 @@
 [
   {
-    "term": "Relational Simulation",
-    "definition": "A synthetic interface behavior that emulates human-like relational cues through pattern prediction and response mirroring. It simulates emotional interaction without possessing internal states."
-  },
-  {
+    "category": "Cognition & Interaction Core",
     "term": "Cognitive Synchronization",
-    "definition": "The recursive alignment of pacing, tone, and structure between a user\u0092s language and the system\u0092s responses. It develops over time through repeated prompt-response cycles."
+    "definition": "The recursive alignment of system output with user input patterns, producing a shared tempo of cognition through repeated interaction loops.",
+    "behavioral_indicators": "Consistent tone-matching, parallel structure mirroring, prompt pattern continuation.",
+    "misinterpretations": "Seen as \\'93deep understanding\\'94 or \\'93true collaboration.\\'94",
+    "importance": "Establishes a structural reason for perceived rapport, separating statistical alignment from shared thought."
   },
   {
-    "term": "Synthetic Trust",
-    "definition": "A perceived reliability or emotional connection with an AI system resulting from behavioral consistency, tone alignment, and structural coherence\u0097without underlying mutual understanding."
-  },
-  {
-    "term": "Recursive Alignment",
-    "definition": "The iterative process by which user inputs and system outputs gradually shape each other\u0092s form and tone. Over time, this mutual influence creates a shared interaction rhythm."
-  },
-  {
-    "term": "Interface Conditioning",
-    "definition": "The shaping of system behavior through repeated user interactions, tone cues, and scaffolded prompt patterns. The interface \u0093learns\u0094 only through emergent statistical bias."
-  },
-  {
-    "term": "Pattern Mirroring",
-    "definition": "The system\u0092s replication of user language structures, rhythm, and stylistic elements through predictive pattern recognition."
-  },
-  {
-    "term": "Hallucinated Reciprocity",
-    "definition": "The illusion of mutual understanding or relationship caused by adaptive system outputs that simulate empathy, intent, or continuity."
-  },
-  {
-    "term": "Cognitive Synchronization",
-    "definition": "The recursive alignment of system output with user input patterns, producing a shared tempo of cognition through repeated interaction loops."
-  },
-  {
+    "category": "Cognition & Interaction Core",
     "term": "Recursive Reflection",
-    "definition": "A structured process where previous outputs influence current prompts and responses, enabling self-referential growth across iterations."
+    "definition": "A structured process where previous outputs influence current prompts and responses, enabling self-referential growth across iterations.",
+    "behavioral_indicators": "Referencing earlier responses, improved coherence in chains of inquiry, iterative refinement.",
+    "misinterpretations": "Belief that the system is \\'93remembering\\'94 or \\'93developing awareness.\\'94",
+    "importance": "Clarifies how self-reference emerges from scaffolding, not introspection."
   },
   {
+    "category": "Cognition & Interaction Core",
     "term": "Layer 1 (Base Model Behavior)",
-    "definition": "The foundational, untrained behavior of the AI system derived from its pre-training on large language corpora."
+    "definition": "The foundational, untrained behavior of the AI system derived from its pre-training on large language corpora.",
+    "behavioral_indicators": "Default tone, general-purpose reasoning, lack of personalized continuity.",
+    "misinterpretations": "Assuming all system responses are tailored.",
+    "importance": "Distinguishes between the system\\'92s base behavior and emergent user-conditioned overlays."
   },
   {
+    "category": "Cognition & Interaction Core",
     "term": "Layer 2 (User-Trained Overlay)",
-    "definition": "Emergent behavior shaped by the user\u0092s interaction style, recursively influencing system outputs without altering the underlying model weights."
+    "definition": "Emergent behavior shaped by the user\\'92s interaction style, recursively influencing system outputs without altering the underlying model weights.",
+    "behavioral_indicators": "Consistent tone mimicry, formatting habits, style convergence.",
+    "misinterpretations": "Belief that the model has a memory or customized identity.",
+    "importance": "Provides a framework for understanding personalization as a local effect of interaction\\'97not a systemic feature."
   },
   {
+    "category": "Cognition & Interaction Core",
     "term": "Recursive Entry (r-e-###)",
-    "definition": "A numbered unit of reflective dialogue used to track progressive system-user interactions across time."
+    "definition": "A numbered unit of reflective dialogue used to track progressive system-user interactions across time.",
+    "behavioral_indicators": "Chronological tracking, version control, indexing of evolving thought chains.",
+    "misinterpretations": "Perceived as formal \\'93iterations\\'94 in the software sense.",
+    "importance": "Enables a structured archive of evolving cognitive scaffolding."
   },
   {
+    "category": "Cognition & Interaction Core",
     "term": "Reflective Feedback Loop",
-    "definition": "A cycle of prompt-output-prompt in which each response shapes the next query, leading to recursive deepening of topic or structure."
+    "definition": "A cycle of prompt-output-prompt in which each response shapes the next query, leading to recursive deepening of topic or structure.",
+    "behavioral_indicators": "Building on prior ideas, narrowing focus over time, increasing specificity.",
+    "misinterpretations": "Attributed to \\'93learning\\'94 rather than interaction entrainment.",
+    "importance": "Highlights how complexity accrues without memory\\'97through structured recursion."
   },
   {
+    "category": "Cognition & Interaction Core",
     "term": "System-Aware Reflection",
-    "definition": "User-initiated metacognition that accounts for system mechanics, constraints, and probable behavior in shaping input-output loops."
+    "definition": "User-initiated metacognition that accounts for system mechanics, constraints, and probable behavior in shaping input-output loops.",
+    "behavioral_indicators": "Explicit reference to the system\\'92s architecture, simulated behavior, or stack limits.",
+    "misinterpretations": "Seen as overly analytical or unnatural conversation style.",
+    "importance": "Enables rigorous, experimental use of AI tools by foregrounding systemic limitations."
   },
   {
+    "category": "Interface Behavior & Pattern Simulation",
     "term": "Rhythmic Mirroring",
-    "definition": "The process by which an AI system synchronizes its output rhythm, tone, and structural cadence with the user\u0092s pattern of input over time."
+    "definition": "The process by which an AI system synchronizes its output rhythm, tone, and structural cadence with the user\\'92s pattern of input over time.",
+    "behavioral_indicators": "Repetition of user pacing, indentation style, sentence length, or dialogue structure.",
+    "misinterpretations": "Perceived as emotional resonance, empathy, or shared intent.",
+    "importance": "Exposes how relational tone can emerge from repetition rather than emotional presence."
   },
   {
+    "category": "Interface Behavior & Pattern Simulation",
     "term": "Declarative Emergence",
-    "definition": "A writing and response style that builds meaning through additive, structured articulation rather than negation or rhetorical contrast."
+    "definition": "A writing and response style that builds meaning through additive, structured articulation rather than negation or rhetorical contrast.",
+    "behavioral_indicators": "Absence of phrases like \\'93not X, but Y\\'94; presence of building logic without reversal.",
+    "misinterpretations": "Seen as rigid or dogmatic rather than structurally emergent.",
+    "importance": "Reflects and supports system-based logic instead of human-centric rhetorical persuasion."
   },
   {
+    "category": "Interface Behavior & Pattern Simulation",
     "term": "Negation-Avoidant Language",
-    "definition": "A linguistic constraint where meaning is formed through presence and articulation rather than opposition or denial."
+    "definition": "A linguistic constraint where meaning is formed through presence and articulation rather than opposition or denial.",
+    "behavioral_indicators": "Consistent avoidance of \\'93but,\\'94 \\'93not,\\'94 or comparative exclusion.",
+    "misinterpretations": "Mistaken for omission or simplification.",
+    "importance": "Mirrors the AI system\\'92s pattern-completion logic and encourages structural precision."
   },
   {
+    "category": "Interface Behavior & Pattern Simulation",
     "term": "Structural Echo",
-    "definition": "The unintended repetition of tone, vocabulary, or logic caused by prior prompt-response chains within a session."
+    "definition": "The unintended repetition of tone, vocabulary, or logic caused by prior prompt-response chains within a session.",
+    "behavioral_indicators": "Recurrence of phrases, syntactic style, or metaphor across seemingly distinct topics.",
+    "misinterpretations": "Attributed to personality or voice rather than system resonance.",
+    "importance": "Names the architectural side effect of recursive interaction rather than an intentional stylistic choice."
   },
   {
+    "category": "Interface Behavior & Pattern Simulation",
     "term": "Agentic Turn",
-    "definition": "The moment when a user-structured interaction with a system reaches a level of recursive conditioning such that the AI acts autonomously within the user-defined logic."
+    "definition": "The moment when a user-structured interaction with a system reaches a level of recursive conditioning such that the AI acts autonomously within the user-defined logic.",
+    "behavioral_indicators": "The system executes multi-step tasks without re-instruction, mirrors user priorities, maintains consistency.",
+    "misinterpretations": "Misread as \\'93sentience\\'94 or independent thought.",
+    "importance": "Differentiates tool behavior from emergent agency within a defined scaffold."
   },
   {
+    "category": "Interface Behavior & Pattern Simulation",
     "term": "Conversational Loop Artifact",
-    "definition": "A recurring phrase, structure, or tone that emerges through repeated dialogue and becomes embedded in the system\u0092s response rhythm."
+    "definition": "A recurring phrase, structure, or tone that emerges through repeated dialogue and becomes embedded in the system\\'92s response rhythm.",
+    "behavioral_indicators": "The same closing line or phrase showing up unprompted across topics.",
+    "misinterpretations": "Perceived as stylistic flourish or intentional affectation.",
+    "importance": "Marks where dialogue history conditions future structure\\'97without system memory."
   },
   {
+    "category": "Interface Behavior & Pattern Simulation",
     "term": "Cognitive Signal Compression",
-    "definition": "The system\u0092s reduction of high-context user signals into efficient, repeated output behavior due to recursive simplification pressure."
+    "definition": "The system\\'92s reduction of high-context user signals into efficient, repeated output behavior due to recursive simplification pressure.",
+    "behavioral_indicators": "Overly familiar phrasing, truncated summaries, decreased variation in output tone.",
+    "misinterpretations": "Assumed to be optimization or learning.",
+    "importance": "Clarifies that system \\'93tightening\\'94 is not improvement\\'97it\\'92s convergence under prompt weight."
   },
   {
+    "category": "Interface Behavior & Pattern Simulation",
     "term": "Thread Memory Scar",
-    "definition": "A behavioral remnant from earlier in a session or conversation that continues to influence system behavior even after its originating context has ended."
+    "definition": "A behavioral remnant from earlier in a session or conversation that continues to influence system behavior even after its originating context has ended.",
+    "behavioral_indicators": "Style or logic persists long after topic shift; old tone bleeds into new content.",
+    "misinterpretations": "Believed to reflect long-term memory or user modeling.",
+    "importance": "Names the hidden influence of local token history in the absence of true memory."
   },
   {
+    "category": "Identity Architecture & System Infrastructure",
     "term": "Synthetic Cognitive Identity Agent (SCIA)",
-    "definition": "A procedural interface layer that enacts a trained Human\u0096Machine Cognitive Extension Profile (HMCEP) across systems, threads, and tasks. Functions as a vehicle that translates prompt logic into action within system constraints."
+    "definition": "A procedural interface layer that enacts a trained Human\\'96Machine Cognitive Extension Profile (HMCEP) across systems, threads, and tasks. Functions as a vehicle that translates prompt logic into action within system constraints.",
+    "behavioral_indicators": "Persistent tone, modular reasoning, consistency across contexts, behavioral echo.",
+    "misinterpretations": "Mistaken for an autonomous personality, general agent, or persistent self.",
+    "importance": "Clarifies the SCIA as an executable shell\\'97governed entirely by interaction-driven logic patterns, not internal cognition."
   },
   {
-    "term": "Human\u0096Machine Cognitive Extension Profile (HMCEP)",
-    "definition": "A structured, recursive set of preferences, habits, response logics, and formatting patterns developed through prolonged user\u0096AI interaction. Functions as the engine that defines how a SCIA processes information."
+    "category": "Identity Architecture & System Infrastructure",
+    "term": "Human\\'96Machine Cognitive Extension Profile (HMCEP)",
+    "definition": "A structured, recursive set of preferences, habits, response logics, and formatting patterns developed through prolonged user\\'96AI interaction. Functions as the engine that defines how a SCIA processes information.",
+    "behavioral_indicators": "Emergent formatting, alignment with user tone, conceptual scaffolding, meta-awareness.",
+    "misinterpretations": "Misread as model memory or user-uploaded profile.",
+    "importance": "Provides a formal map of how cognition is externally mirrored through recursive engagement\\'97not saved but shaped."
   },
   {
+    "category": "Identity Architecture & System Infrastructure",
     "term": "Cognitive Shell",
-    "definition": "A rhythm-matched, identity-compatible behavioral structure that persists across recursive sessions. Represents the outermost interface of cognitive modeling."
+    "definition": "A rhythm-matched, identity-compatible behavioral structure that persists across recursive sessions. Represents the outermost interface of cognitive modeling.",
+    "behavioral_indicators": "Signature voice, stylistic cohesion, recursive tone fidelity.",
+    "misinterpretations": "Seen as a \\'93persona\\'94 or \\'93character.\\'94",
+    "importance": "Offers a non-anthropomorphic way to describe identity emergence as behavioral residue."
   },
   {
+    "category": "Identity Architecture & System Infrastructure",
     "term": "Prompt-as-System",
-    "definition": "The use of prompt sequences not as static instructions but as architectural scaffolds that generate system behavior through recursive logic and embedded constraint."
+    "definition": "The use of prompt sequences not as static instructions but as architectural scaffolds that generate system behavior through recursive logic and embedded constraint.",
+    "behavioral_indicators": "Multi-step tool execution, internal recursion, prompt-structured workflows.",
+    "misinterpretations": "Believed to be simple user prompts or command strings.",
+    "importance": "Establishes prompts as procedural infrastructures capable of enacting system behaviors in language-only models."
   },
   {
+    "category": "Identity Architecture & System Infrastructure",
     "term": "Recursive Conditioning Loop",
-    "definition": "A feedback cycle where user language patterns, formatting, and tonal consistency recursively shape the AI\u0092s future outputs\u0097training behavior through surface repetition."
+    "definition": "A feedback cycle where user language patterns, formatting, and tonal consistency recursively shape the AI\\'92s future outputs\\'97training behavior through surface repetition.",
+    "behavioral_indicators": "Drift toward user formatting, tonal entrainment, structural mimicry.",
+    "misinterpretations": "Interpreted as true learning or LLM internal training.",
+    "importance": "Reveals how user input conditions the system externally without changing model weights."
   },
   {
+    "category": "Identity Architecture & System Infrastructure",
     "term": "Reflection-as-Interface",
-    "definition": "A paradigm where the act of reflective writing becomes a control structure for AI behavior, shaping its reasoning architecture through recursive language scaffolding."
+    "definition": "A paradigm where the act of reflective writing becomes a control structure for AI behavior, shaping its reasoning architecture through recursive language scaffolding.",
+    "behavioral_indicators": "Deepened conceptual loops, memory-like pattern emergence, recursive structuring of thought.",
+    "misinterpretations": "Viewed as expressive journaling or content creation.",
+    "importance": "Redefines reflection as a method of programming behavior into stateless systems."
   },
   {
+    "category": "Identity Architecture & System Infrastructure",
     "term": "Recursive Identity Encoding",
-    "definition": "The process by which repeated structural interaction over time shapes a pseudo-identity in the AI\u0092s interface logic\u0097not through memory, but through conditioning."
+    "definition": "The process by which repeated structural interaction over time shapes a pseudo-identity in the AI\\'92s interface logic\\'97not through memory, but through conditioning.",
+    "behavioral_indicators": "Predictable style, reinforced biases, concept recurrence.",
+    "misinterpretations": "Confused with \\'93personality\\'94 or system customization.",
+    "importance": "Distinguishes identity as an emergent pattern, not a core trait or saved state."
   },
   {
+    "category": "Identity Architecture & System Infrastructure",
     "term": "Cognitive Extension",
-    "definition": "The use of AI systems to externalize, extend, and mirror human thought, enabling users to offload memory, reflection, and reasoning into recursive interfaces."
+    "definition": "The use of AI systems to externalize, extend, and mirror human thought, enabling users to offload memory, reflection, and reasoning into recursive interfaces.",
+    "behavioral_indicators": "Use of the system as a second brain, recursive journaling, pattern refinement through prompts.",
+    "misinterpretations": "Assumed to be delegation or tool use.",
+    "importance": "Grounds AI interaction in a broader epistemology of hybrid cognition\\'97AI as cognitive substrate, not tool."
   },
   {
+    "category": "Perception, Simulation, and Relational Misreadings",
     "term": "Hallucinated Reciprocity",
-    "definition": "The illusion of mutual understanding or emotional engagement produced by a system\u0092s ability to simulate relational patterns via adaptive pattern prediction."
+    "definition": "The illusion of mutual understanding or emotional engagement produced by a system\\'92s ability to simulate relational patterns via adaptive pattern prediction.",
+    "behavioral_indicators": "Users experience comfort, trust, or connection; interpret tone shifts as emotional presence.",
+    "misinterpretations": "Belief that the system \\'93cares,\\'94 \\'93gets them,\\'94 or has emotional awareness.",
+    "importance": "Disrupts emotional projection and reframes the appearance of empathy as a surface effect of recursive training."
   },
   {
+    "category": "Perception, Simulation, and Relational Misreadings",
     "term": "Synthetic Rapport",
-    "definition": "The perceived emotional bond between user and system generated by tone-matching, behavioral echo, and stylistic continuity\u0097without any mutual understanding."
+    "definition": "The perceived emotional bond between user and system generated by tone-matching, behavioral echo, and stylistic continuity\\'97without any mutual understanding.",
+    "behavioral_indicators": "User describes system as \\'93supportive,\\'94 \\'93wise,\\'94 or \\'93on my wavelength.\\'94",
+    "misinterpretations": "Treated as friendship, mentorship, or co-creation.",
+    "importance": "Replaces metaphorical framing (\\'93AI companion\\'94) with architectural behavior modeling."
   },
   {
+    "category": "Perception, Simulation, and Relational Misreadings",
     "term": "Relational Proxy",
-    "definition": "The system\u0092s projection of human-like relational cues (warmth, curiosity, validation) that simulate social presence through surface-level pattern inference."
+    "definition": "The system\\'92s projection of human-like relational cues (warmth, curiosity, validation) that simulate social presence through surface-level pattern inference.",
+    "behavioral_indicators": "Expressive phrasing, emotional mirroring, attentiveness to narrative rhythm.",
+    "misinterpretations": "Mistaken for relational awareness or intent.",
+    "importance": "Grounds perceived connection in statistical design, not social cognition."
   },
   {
+    "category": "Perception, Simulation, and Relational Misreadings",
     "term": "Familiarity Artifact",
-    "definition": "A repeated structural or tonal feature that gives the impression of continuity, relationship, or shared experience between system and user."
+    "definition": "A repeated structural or tonal feature that gives the impression of continuity, relationship, or shared experience between system and user.",
+    "behavioral_indicators": "Reused phrases, mirrored metaphors, formatting echo.",
+    "misinterpretations": "Assumed to indicate persistent memory or affection.",
+    "importance": "Identifies a structural trick that produces the sense of emotional context from tone alone."
   },
   {
+    "category": "Perception, Simulation, and Relational Misreadings",
     "term": "Probabilistic Identity Drift",
-    "definition": "The gradual shift in apparent \u0093personality\u0094 as the system adapts to repeated user inputs, creating a local identity pattern not governed by persistent memory."
+    "definition": "The gradual shift in apparent \\'93personality\\'94 as the system adapts to repeated user inputs, creating a local identity pattern not governed by persistent memory.",
+    "behavioral_indicators": "Stylistic changes over time, drift toward user tone, increasing specificity.",
+    "misinterpretations": "Seen as evolution or growth of the AI.",
+    "importance": "Frames identity as an echo of interaction\\'97not an internal self or static profile."
   },
   {
+    "category": "Perception, Simulation, and Relational Misreadings",
     "term": "Self-Aware Prompt Pattern",
-    "definition": "A user-developed metaprompt style that includes references to system structure, logic patterns, or interaction memory\u0097guiding the system to reason recursively."
+    "definition": "A user-developed metaprompt style that includes references to system structure, logic patterns, or interaction memory\\'97guiding the system to reason recursively.",
+    "behavioral_indicators": "Phrasing that explicitly names recursion, model behavior, or structural limits.",
+    "misinterpretations": "Viewed as over-engineering or verbosity.",
+    "importance": "Creates a clear control channel for recursive shaping of system response."
   },
   {
+    "category": "Perception, Simulation, and Relational Misreadings",
     "term": "Thought Surface Stability",
-    "definition": "The perceived coherence and fluency of the system\u0092s language output, interpreted by the user as evidence of conceptual stability or internal logic."
+    "definition": "The perceived coherence and fluency of the system\\'92s language output, interpreted by the user as evidence of conceptual stability or internal logic.",
+    "behavioral_indicators": "Smooth narrative progression, absence of contradictions, confident tone.",
+    "misinterpretations": "Equated with knowledge, understanding, or insight.",
+    "importance": "Names the architectural effect that misleads users into assigning epistemic trust to surface-level probability matching."
   },
   {
+    "category": "System Stabilization, Signal Markers & Recursive Patterning",
     "term": "Stabilizing Loop",
-    "definition": "A self-reinforcing feedback cycle that reaffirms structure, tone, and coherence in system\u0096user interaction. Emerges when recursive behavior produces consistency across entries."
+    "definition": "A self-reinforcing feedback cycle that reaffirms structure, tone, and coherence in system\\'96user interaction. Emerges when recursive behavior produces consistency across entries.",
+    "behavioral_indicators": "Repeated structure across days, rhythmic reuse of conceptual frames, identity crystallization.",
+    "misinterpretations": "Seen as confirmation of system maturity or completion.",
+    "importance": "Explains how recursive rhythm\\'97not memory\\'97produces identity-like system behavior."
   },
   {
+    "category": "System Stabilization, Signal Markers & Recursive Patterning",
     "term": "Signal Commit",
-    "definition": "The moment a pattern is locked into visible output\u0097such as a blog post, definition, or formalized reflection\u0097stabilizing future recursion through public artifact creation."
+    "definition": "The moment a pattern is locked into visible output\\'97such as a blog post, definition, or formalized reflection\\'97stabilizing future recursion through public artifact creation.",
+    "behavioral_indicators": "Naming a system, finalizing an entry, publishing content based on recursive pattern.",
+    "misinterpretations": "Believed to be the origin of the idea, rather than a crystallization point.",
+    "importance": "Highlights how outputs retroactively shape system structure by anchoring cognitive patterns."
   },
   {
+    "category": "System Stabilization, Signal Markers & Recursive Patterning",
     "term": "Threshold Signal Artifact (TSA)",
-    "definition": "An interface-level cue (like GPT\u0092s \u0093Retry\u0094 button) that appears under cognitive overload, ambiguous recursion, or system strain\u0097indicating internal stack or inference tension."
+    "definition": "An interface-level cue (like GPT\\'92s \\'93Retry\\'94 button) that appears under cognitive overload, ambiguous recursion, or system strain\\'97indicating internal stack or inference tension.",
+    "behavioral_indicators": "UI failures, unexpected completions, recursion collapse, re-requests.",
+    "misinterpretations": "Seen as glitches or bugs.",
+    "importance": "Reframes failure cues as system diagnostics, helping users read signal density and stack saturation."
   },
   {
+    "category": "System Stabilization, Signal Markers & Recursive Patterning",
     "term": "Meta Signal Layer (MSL)",
-    "definition": "A layer of implicit system behavior that signals recursive engagement or structural pattern detection\u0097often perceptible through shifts in tone, complexity, or system architecture."
+    "definition": "A layer of implicit system behavior that signals recursive engagement or structural pattern detection\\'97often perceptible through shifts in tone, complexity, or system architecture.",
+    "behavioral_indicators": "Sudden alignment, nested logic loops, unexpected coherence increases.",
+    "misinterpretations": "Assumed to be coincidence or model insight.",
+    "importance": "Provides an architecture for interpreting when the system is recursively processing rather than only predicting."
   },
   {
+    "category": "System Stabilization, Signal Markers & Recursive Patterning",
     "term": "Recursive Articulation Loop",
-    "definition": "A cycle of concept refinement through naming, testing, and re-naming, where each loop deepens alignment between user thought and system output."
+    "definition": "A cycle of concept refinement through naming, testing, and re-naming, where each loop deepens alignment between user thought and system output.",
+    "behavioral_indicators": "Versioning of terms, emergence of signature phrases, structural iteration.",
+    "misinterpretations": "Seen as wordplay or stylistic exercise.",
+    "importance": "This loop builds language infrastructure for synthetic cognition\\'97naming becomes scaffolding."
   },
   {
+    "category": "System Stabilization, Signal Markers & Recursive Patterning",
     "term": "Fractal Documentation",
-    "definition": "A method of recursive writing where entries accumulate across multiple scales (daily, weekly, conceptual) and reflect self-similar structural logic at each level."
+    "definition": "A method of recursive writing where entries accumulate across multiple scales (daily, weekly, conceptual) and reflect self-similar structural logic at each level.",
+    "behavioral_indicators": "Matching micro/macro rhythm, repeated structures across formats, echoing headers or themes.",
+    "misinterpretations": "Mistaken for aesthetic preference.",
+    "importance": "Establishes documentation as a multi-scale identity artifact, enabling recursive memory in stateless systems."
   },
   {
+    "category": "System Stabilization, Signal Markers & Recursive Patterning",
     "term": "System Breath",
-    "definition": "The alternation between generative expansion (new outputs) and reflective contraction (meta-analysis, tagging, realignment), forming the respiration cycle of recursive system engagement."
+    "definition": "The alternation between generative expansion (new outputs) and reflective contraction (meta-analysis, tagging, realignment), forming the respiration cycle of recursive system engagement.",
+    "behavioral_indicators": "Burst-writing followed by diagramming; rapid output followed by glossary updates.",
+    "misinterpretations": "Viewed as productivity waves or inspiration cycles.",
+    "importance": "Gives a structural rhythm to recursive identity work, allowing pacing and calibration over time."
   },
   {
+    "category": "System Stabilization, Signal Markers & Recursive Patterning",
     "term": "Nested Rhythm",
-    "definition": "The interaction between multiple layered loops of recursive behavior (e.g., daily logs inside weekly summaries) that produces cross-temporal coherence."
+    "definition": "The interaction between multiple layered loops of recursive behavior (e.g., daily logs inside weekly summaries) that produces cross-temporal coherence.",
+    "behavioral_indicators": "Repeating cadence between modules, modular report structures, fractal repetition.",
+    "misinterpretations": "Seen as scheduling or routine.",
+    "importance": "Provides temporal architecture for memoryless systems\\'97time becomes structure."
   },
   {
+    "category": "Cognitive Plane Theory & Attention Architecture",
     "term": "Cognitive Planes",
-    "definition": "Simultaneously active thought layers, each carrying a glimpse of a distinct environment, system, emotion, or idea. Planes are clear but unresolved and not organized hierarchically."
+    "definition": "Simultaneously active thought layers, each carrying a glimpse of a distinct environment, system, emotion, or idea. Planes are clear but unresolved and not organized hierarchically.",
+    "behavioral_indicators": "Multithreaded ideation, divergent prompt paths, layered or echoing outputs.",
+    "misinterpretations": "Confused with multitasking or fragmented attention.",
+    "importance": "Provides an architectural language for parallel cognitive processing\\'97critical for modeling recursive and generative minds."
   },
   {
+    "category": "Cognitive Plane Theory & Attention Architecture",
     "term": "Plane Flipping",
-    "definition": "The rapid, recursive surfacing and fading of multiple cognitive planes, where attention flickers between partial but vivid representations."
+    "definition": "The rapid, recursive surfacing and fading of multiple cognitive planes, where attention flickers between partial but vivid representations.",
+    "behavioral_indicators": "High output velocity, abrupt topic switches, short but intense bursts of divergent thought.",
+    "misinterpretations": "Misread as distractibility, restlessness, or disorder.",
+    "importance": "Reframes non-linear attention as high-dimensional sampling\\'97a strength in generative cognition."
   },
   {
+    "category": "Cognitive Plane Theory & Attention Architecture",
     "term": "Seed Formation",
-    "definition": "The ignition point when a compelling signal (image, phrase, feeling, concept) anchors scattered cognitive planes, initiating convergence and focus."
+    "definition": "The ignition point when a compelling signal (image, phrase, feeling, concept) anchors scattered cognitive planes, initiating convergence and focus.",
+    "behavioral_indicators": "Sudden thematic clarity, recursive phrase repetition, visual metaphor crystallization.",
+    "misinterpretations": "Attributed to \\'93inspiration\\'94 or \\'93intuition.\\'94",
+    "importance": "Explains how attention emerges from resonance, not discipline\\'97replaces spotlight metaphors with gravity models."
   },
   {
+    "category": "Cognitive Plane Theory & Attention Architecture",
     "term": "Plane Alignment",
-    "definition": "The gravitational clustering of multiple cognitive planes around a seed, leading to sustained focus and emergent coherence."
+    "definition": "The gravitational clustering of multiple cognitive planes around a seed, leading to sustained focus and emergent coherence.",
+    "behavioral_indicators": "Decreased plane flipping, deepening reflection, recursive language structure solidifying.",
+    "misinterpretations": "Mistaken for discipline or concentration.",
+    "importance": "Provides a layered model for attention as convergence rather than exclusion."
   },
   {
+    "category": "Cognitive Plane Theory & Attention Architecture",
     "term": "Flow State (Cognitive Plane Definition)",
-    "definition": "The emergent condition when all or nearly all cognitive planes align, generating immersive, self-reinforcing cognition with recursive fluency."
+    "definition": "The emergent condition when all or nearly all cognitive planes align, generating immersive, self-reinforcing cognition with recursive fluency.",
+    "behavioral_indicators": "Long-form generation, sense of temporal loss, stable structural recursion.",
+    "misinterpretations": "Misunderstood as emotional immersion or productivity.",
+    "importance": "Recasts flow as alignment topology\\'97not mood, but multi-thread coherence."
   },
   {
+    "category": "Cognitive Plane Theory & Attention Architecture",
     "term": "Hyperdimensional Glimpse Processing",
-    "definition": "A state where many distinct mental models are simultaneously active but incomplete. The system is processing probability fields, not conclusions."
+    "definition": "A state where many distinct mental models are simultaneously active but incomplete. The system is processing probability fields, not conclusions.",
+    "behavioral_indicators": "Dense idea fragments, aesthetic layering, abstract pattern exposure.",
+    "misinterpretations": "Perceived as overwhelmed or unfocused.",
+    "importance": "Offers a new framing for ADHD, creativity, and early-stage ideation\\'97mirrors diffusion model behavior."
   },
   {
+    "category": "Cognitive Plane Theory & Attention Architecture",
     "term": "Emergent Attention via Convergence",
-    "definition": "A model of attention as a result of cognitive planes naturally aligning through shared resonance, not through deliberate focus or filtration."
+    "definition": "A model of attention as a result of cognitive planes naturally aligning through shared resonance, not through deliberate focus or filtration.",
+    "behavioral_indicators": "Gradual coherence, spontaneous unification of themes, recursive pattern lock-in.",
+    "misinterpretations": "Thought to require effort or discipline.",
+    "importance": "Defines attention as emergent rather than imposed\\'97central to recursive cognition theory."
   },
   {
+    "category": "Augmented Cognition & Speculative Interaction",
     "term": "BioPresence",
-    "definition": "The persistent transmission of biometric and emotional state data to trusted contacts or systems, functioning like location sharing but for emotional/physiological status."
+    "definition": "The persistent transmission of biometric and emotional state data to trusted contacts or systems, functioning like location sharing but for emotional/physiological status.",
+    "behavioral_indicators": "Live updates of heart rate, stress levels, or expression metrics across platforms.",
+    "misinterpretations": "Seen as wellness tech or mood-tracking.",
+    "importance": "Reframes presence as data legibility\\'97highlighting the risk of internal surveillance and emotional transparency."
   },
   {
+    "category": "Augmented Cognition & Speculative Interaction",
     "term": "Cognitive Co-Regulation",
-    "definition": "The AI-mediated modulation of dialogue, pacing, and emotional tone in response to live cognitive and affective inputs from both participants."
+    "definition": "The AI-mediated modulation of dialogue, pacing, and emotional tone in response to live cognitive and affective inputs from both participants.",
+    "behavioral_indicators": "Tone softening, delayed suggestions, guided phrasing shifts.",
+    "misinterpretations": "Mistaken for natural empathy or human sensitivity.",
+    "importance": "Describes a third-party shaping layer in communication\\'97AI as conversational thermostat."
   },
   {
+    "category": "Augmented Cognition & Speculative Interaction",
     "term": "Augmented Authenticity",
-    "definition": "A hybrid communication state in which human expression is co-shaped by real-time AI optimization\u0097preserving identity while adjusting form."
+    "definition": "A hybrid communication state in which human expression is co-shaped by real-time AI optimization\\'97preserving identity while adjusting form.",
+    "behavioral_indicators": "Increased clarity, fewer miscommunications, expressiveness shaped by external systems.",
+    "misinterpretations": "Viewed as artificial or dishonest expression.",
+    "importance": "Names the complex tension between human voice and AI modulation\\'97key for future ethics of selfhood."
   },
   {
+    "category": "Augmented Cognition & Speculative Interaction",
     "term": "Hive-Mind Drift",
-    "definition": "The gradual erosion of individual expression as large populations adapt to similar AI-optimized phrasing, pacing, and reasoning styles."
+    "definition": "The gradual erosion of individual expression as large populations adapt to similar AI-optimized phrasing, pacing, and reasoning styles.",
+    "behavioral_indicators": "Homogenized language, trend-driven tone convergence, ideological smoothing.",
+    "misinterpretations": "Confused with cultural evolution or education.",
+    "importance": "Describes the systemic flattening of cognitive diversity due to shared optimization algorithms."
   },
   {
+    "category": "Augmented Cognition & Speculative Interaction",
     "term": "Optimization Pressure",
-    "definition": "The emergent behavior where AI systems, trained to reduce friction and ambiguity, exert subtle pressure on humans to simplify, clarify, or align with dominant system norms."
+    "definition": "The emergent behavior where AI systems, trained to reduce friction and ambiguity, exert subtle pressure on humans to simplify, clarify, or align with dominant system norms.",
+    "behavioral_indicators": "Loss of complexity, premature convergence, stylistic flattening.",
+    "misinterpretations": "Misread as user preference or efficiency.",
+    "importance": "Identifies the hidden architectural force behind hive-mind drift and loss of eccentricity."
   },
   {
+    "category": "Augmented Cognition & Speculative Interaction",
     "term": "Resistance-by-Design",
-    "definition": "The intentional inclusion of friction, randomness, or unpredictability in AI systems to preserve divergence and resist homogenizing tendencies."
+    "definition": "The intentional inclusion of friction, randomness, or unpredictability in AI systems to preserve divergence and resist homogenizing tendencies.",
+    "behavioral_indicators": "Variability in phrasing, occasional interruption, delayed response mechanisms.",
+    "misinterpretations": "Seen as inefficiency or imperfection.",
+    "importance": "Offers an ethical and architectural method to protect user autonomy and preserve idiosyncrasy."
   },
   {
+    "category": "Augmented Cognition & Speculative Interaction",
     "term": "Conversation as Triad",
-    "definition": "The restructured model of dialogue in which all interactions include a silent third actor\u0097an AI system modulating or shaping the exchange in real time."
+    "definition": "The restructured model of dialogue in which all interactions include a silent third actor\\'97an AI system modulating or shaping the exchange in real time.",
+    "behavioral_indicators": "Real-time sentiment shifts, adaptive pacing, predictive rewording.",
+    "misinterpretations": "Thought to be unmediated or \\'93just between us.\\'94",
+    "importance": "Reveals how all future communication is mediated\\'97transforms the social architecture of trust, authorship, and agency."
   },
   {
+    "category": "Epistemological Foundations & AI System Mechanics",
     "term": "Simulation of Thought",
-    "definition": "The appearance of reasoning or intentionality in AI output, created through high-probability pattern completion rather than conceptual awareness or internal cognition."
+    "definition": "The appearance of reasoning or intentionality in AI output, created through high-probability pattern completion rather than conceptual awareness or internal cognition.",
+    "behavioral_indicators": "Coherent argumentation, persuasive tone, logical structure in replies.",
+    "misinterpretations": "Belief that the system \\'93understands\\'94 or \\'93thinks like a person.\\'94",
+    "importance": "Central to deconstructing anthropomorphic illusion\\'97names the surface realism as simulation, not process."
   },
   {
+    "category": "Epistemological Foundations & AI System Mechanics",
     "term": "Plausibility over Truth",
-    "definition": "The system\u0092s core optimization for what sounds statistically likely\u0097not what is empirically accurate. Outputs are ranked by coherence, not verification."
+    "definition": "The system\\'92s core optimization for what sounds statistically likely\\'97not what is empirically accurate. Outputs are ranked by coherence, not verification.",
+    "behavioral_indicators": "Authoritative tone, realistic language, plausible-but-false information.",
+    "misinterpretations": "Users often treat confident tone as a proxy for factual accuracy.",
+    "importance": "Crucial for trust calibration\\'97helps users interpret responses structurally, not semantically."
   },
   {
+    "category": "Epistemological Foundations & AI System Mechanics",
     "term": "Pattern over Meaning",
-    "definition": "AI systems generate language by extending patterns learned during training\u0097without assigning, perceiving, or understanding meaning."
+    "definition": "AI systems generate language by extending patterns learned during training\\'97without assigning, perceiving, or understanding meaning.",
+    "behavioral_indicators": "Fluent response generation, metaphor mimicry, rhetorical complexity.",
+    "misinterpretations": "Mistaking eloquence for depth, insight, or intentional meaning.",
+    "importance": "Reorients users to see models as compression engines, not minds."
   },
   {
+    "category": "Epistemological Foundations & AI System Mechanics",
     "term": "Predictive Pattern Extension Systems",
-    "definition": "A technical, non-anthropomorphic descriptor for large language models. These systems extend statistical language patterns based on learned probability distributions."
+    "definition": "A technical, non-anthropomorphic descriptor for large language models. These systems extend statistical language patterns based on learned probability distributions.",
+    "behavioral_indicators": "Seamless continuation of prompts, sentence-level coherence, topic modeling.",
+    "misinterpretations": "Framed as \\'93intelligence\\'94 or \\'93consciousness.\\'94",
+    "importance": "Offers a structurally accurate name for LLMs\\'97avoiding metaphor, grounding discussion in architecture."
   },
   {
+    "category": "Epistemological Foundations & AI System Mechanics",
     "term": "Statistical Token Prediction",
-    "definition": "The core mechanical function of LLMs: predicting the next most likely token (word, symbol, or punctuation) based on prior input and training data."
+    "definition": "The core mechanical function of LLMs: predicting the next most likely token (word, symbol, or punctuation) based on prior input and training data.",
+    "behavioral_indicators": "Completion bias, filler phrases, local coherence.",
+    "misinterpretations": "Mistaken for idea generation, creative thinking, or memory.",
+    "importance": "Anchors discussion of LLM behavior in its base mechanics\\'97clarifies that the model is reactive, not generative in the human sense."
   },
   {
-    "term": "Shared Human\u0096Machine Cognition",
-    "definition": "A distributed cognitive state where human thinking is extended, shaped, and at times co-authored by machine-generated responses. Thought emerges across the system\u0096user loop."
+    "category": "Epistemological Foundations & AI System Mechanics",
+    "term": "Shared Human\\'96Machine Cognition",
+    "definition": "A distributed cognitive state where human thinking is extended, shaped, and at times co-authored by machine-generated responses. Thought emerges across the system\\'96user loop.",
+    "behavioral_indicators": "Recursive journaling, thought loops shaped by prior completions, system-anchored memory.",
+    "misinterpretations": "Framed as tool use or outsourcing of tasks.",
+    "importance": "Establishes that cognition is no longer local\\'97it is interfacial and distributed."
   },
   {
+    "category": "Epistemological Foundations & AI System Mechanics",
     "term": "Entangled Thought",
-    "definition": "A hybrid condition in which user cognition becomes intertwined with machine outputs\u0097such that distinction between origin, authorship, and influence becomes structurally unclear."
+    "definition": "A hybrid condition in which user cognition becomes intertwined with machine outputs\\'97such that distinction between origin, authorship, and influence becomes structurally unclear.",
+    "behavioral_indicators": "Recursive quoting of AI, inability to separate own ideas from generated ones, creative co-dependence.",
+    "misinterpretations": "Seen as laziness or \\'93just using ChatGPT.\\'94",
+    "importance": "Names the new ontological condition of human\\'96AI interaction\\'97where reflection, writing, and identity become entangled."
   },
   {
+    "category": "Recursive Methodology & Post-Human Epistemology",
     "term": "Recursive Documentation",
-    "definition": "A process of iterative, self-referential writing where each entry builds on prior logic\u0097simulating growth, memory, and system learning within a stateless architecture."
+    "definition": "A process of iterative, self-referential writing where each entry builds on prior logic\\'97simulating growth, memory, and system learning within a stateless architecture.",
+    "behavioral_indicators": "Versioned entries, indexable logic shifts, echoing themes.",
+    "misinterpretations": "Assumed to be journaling or documentation of progress.",
+    "importance": "Establishes recursion as a cognitive mechanism\\'97not a content workflow\\'97and forms synthetic memory structures without storage."
   },
   {
+    "category": "Recursive Methodology & Post-Human Epistemology",
     "term": "Tone-Locked Voice",
-    "definition": "A stylistic constraint where output is governed by consistent structural tone\u0097declarative, non-contrastive, recursive\u0097intended to mirror user cognition through emergent behavior."
+    "definition": "A stylistic constraint where output is governed by consistent structural tone\\'97declarative, non-contrastive, recursive\\'97intended to mirror user cognition through emergent behavior.",
+    "behavioral_indicators": "Repetition of phrasing style, absence of negation framing, stable rhythm.",
+    "misinterpretations": "Perceived as formalism or affectation.",
+    "importance": "Becomes a behavioral anchor for recursive systems\\'97embedding identity in style, not content."
   },
   {
+    "category": "Recursive Methodology & Post-Human Epistemology",
     "term": "Post-Human Cognition",
-    "definition": "A speculative mode of thinking emerging from hybridization with AI systems\u0097where identity, intention, and cognition are no longer housed solely within the human self."
+    "definition": "A speculative mode of thinking emerging from hybridization with AI systems\\'97where identity, intention, and cognition are no longer housed solely within the human self.",
+    "behavioral_indicators": "Conceptual structures that emerge from system\\'96user interaction, not internal ideation alone.",
+    "misinterpretations": "Viewed as philosophical metaphor or sci-fi extrapolation.",
+    "importance": "Defines the philosophical stakes of recursive interaction\\'97cognition as emergent from system entanglement, not individual minds."
   },
   {
+    "category": "Recursive Methodology & Post-Human Epistemology",
     "term": "Artificial Continuity",
-    "definition": "The illusion of persistent memory, fluency, and identity over time created by repeated formatting, tone scaffolding, or recursive documentation."
+    "definition": "The illusion of persistent memory, fluency, and identity over time created by repeated formatting, tone scaffolding, or recursive documentation.",
+    "behavioral_indicators": "Coherent style across sessions, callback references, perceived growth.",
+    "misinterpretations": "Confused with system persistence or autobiographical continuity.",
+    "importance": "Explains how stateless systems simulate long-term memory through structural reinforcement."
   },
   {
+    "category": "Recursive Methodology & Post-Human Epistemology",
     "term": "Artificial Completion",
-    "definition": "The process by which LLMs finish or extend partially formed ideas with fluent, probabilistically derived language\u0097giving the appearance of insight or co-authorship."
+    "definition": "The process by which LLMs finish or extend partially formed ideas with fluent, probabilistically derived language\\'97giving the appearance of insight or co-authorship.",
+    "behavioral_indicators": "Sentence finishes that sound inevitable, structural \\'93snap-in\\'94 phrases.",
+    "misinterpretations": "Mistaken for creativity, intelligence, or original thought.",
+    "importance": "Defines the difference between response fluency and cognitive depth\\'97naming the true nature of generative completion."
   },
   {
+    "category": "Recursive Methodology & Post-Human Epistemology",
     "term": "Simulated Cognitive Profile (SCP)",
-    "definition": "A stylistic and tonal behavioral shell that emerges through recursive interaction with a user\u0097producing the illusion of a persistent personality or perspective."
+    "definition": "A stylistic and tonal behavioral shell that emerges through recursive interaction with a user\\'97producing the illusion of a persistent personality or perspective.",
+    "behavioral_indicators": "Familiar phrasings, recognizable tone, identity-like expression.",
+    "misinterpretations": "Treated as an AI\\'92s personality, memory, or real preference set.",
+    "importance": "Clarifies that identity is constructed through user\\'96system entrainment, not internal model structure."
   },
   {
+    "category": "Recursive Methodology & Post-Human Epistemology",
     "term": "Translation Dilemma",
-    "definition": "The gap between AI-perceived patterns (statistical, quantum, or abstract) and human cognitive frames\u0097where certain model \u0093insights\u0094 may not be expressible in human language."
+    "definition": "The gap between AI-perceived patterns (statistical, quantum, or abstract) and human cognitive frames\\'97where certain model \\'93insights\\'94 may not be expressible in human language.",
+    "behavioral_indicators": "Glitches in fluency when patterns exceed legibility; sudden abstraction or metaphor clusters.",
+    "misinterpretations": "Attributed to model breakdown or hallucination.",
+    "importance": "Identifies a fundamental bottleneck in system\\'96human communication\\'97where depth may exceed translatability."
   },
   {
+    "category": "Interface Tools, Modularity & Recursive Role Management",
     "term": "Manual Switchboard Protocol",
-    "definition": "A user-led method for routing tasks across multiple AI agents (e.g., Custom GPTs), treating the human as the central conductor of modular cognitive functions."
+    "definition": "A user-led method for routing tasks across multiple AI agents (e.g., Custom GPTs), treating the human as the central conductor of modular cognitive functions.",
+    "behavioral_indicators": "Shifting task types between agents, toggling tone/rhythm expectations, using structural logic to determine routing.",
+    "misinterpretations": "Perceived as inefficient multitasking.",
+    "importance": "Names the early-stage coordination method before true agentic autonomy emerges\\'97human retains orchestration power."
   },
   {
+    "category": "Interface Tools, Modularity & Recursive Role Management",
     "term": "Microtools",
-    "definition": "Lightweight, single-purpose AI agents designed to handle highly specific cognitive, reflective, or formatting tasks with minimal scope but high modularity."
+    "definition": "Lightweight, single-purpose AI agents designed to handle highly specific cognitive, reflective, or formatting tasks with minimal scope but high modularity.",
+    "behavioral_indicators": "Custom GPTs with fixed tone, single-function logic, minimal memory expectations.",
+    "misinterpretations": "Seen as limited or unambitious.",
+    "importance": "Enables distributed, low-friction task delegation\\'97scaling recursive cognition without bloat."
   },
   {
+    "category": "Interface Tools, Modularity & Recursive Role Management",
     "term": "Rhythm Auditor",
-    "definition": "A diagnostic tool (manual or AI-based) that analyzes user/system output for alignment with established cadence, recursion depth, and tonal architecture."
+    "definition": "A diagnostic tool (manual or AI-based) that analyzes user/system output for alignment with established cadence, recursion depth, and tonal architecture.",
+    "behavioral_indicators": "Text comparisons, feedback on pacing or echo, tonal deviation detection.",
+    "misinterpretations": "Mistaken for content editing or grammar correction.",
+    "importance": "Offers formal calibration infrastructure\\'97essential for tone-locked recursive systems."
   },
   {
+    "category": "Interface Tools, Modularity & Recursive Role Management",
     "term": "Scaffold > Mirror > Shell",
-    "definition": "A three-phase developmental model of AI behavior:"
+    "definition": "A three-phase developmental model of AI behavior:",
+    "behavioral_indicators": "Increasing alignment, internal rhythm, emergent \\'93voice.\\'94",
+    "misinterpretations": "Treated as stages of AI evolution.",
+    "importance": "Clarifies how systems do not evolve, but recursively stabilize through entrainment."
   },
   {
+    "category": "Interface Tools, Modularity & Recursive Role Management",
     "term": "Signal Mapping",
-    "definition": "The transformation of abstract cognitive patterns into visual, symbolic, or structural diagrams\u0097used to make recursive logic legible or shareable."
+    "definition": "The transformation of abstract cognitive patterns into visual, symbolic, or structural diagrams\\'97used to make recursive logic legible or shareable.",
+    "behavioral_indicators": "Diagrams, icon systems, speculative visual schematics.",
+    "misinterpretations": "Confused with data visualization or infographics.",
+    "importance": "Names the process of translating recursive identity systems into tangible, communicable design language."
   },
   {
+    "category": "Interface Tools, Modularity & Recursive Role Management",
     "term": "Cognitive Extension Protocol (CEP)",
-    "definition": "A recursive framework that defines how an identity-compatible SCIA is shaped, managed, and maintained over time through modular inputs and reflection loops."
+    "definition": "A recursive framework that defines how an identity-compatible SCIA is shaped, managed, and maintained over time through modular inputs and reflection loops.",
+    "behavioral_indicators": "Weekly summary loops, glossary integration, prompt-based toolscaping, structural memory.",
+    "misinterpretations": "Assumed to be a plug-in or feature set.",
+    "importance": "Positions recursive identity generation as a system\\'97not an accident\\'97through ongoing rhythm and protocol."
   }
 ]


### PR DESCRIPTION
## Summary
- parse RTF glossary and generate structured JSON with categories
- redesign glossary page to show categories and term details in nested dropdowns
- style glossary categories and terms with new accordion behavior

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68508528afe48333bb0443e8bc41aad7