### PR TITLE
Add Match Zimmerman portfolio site

### DIFF
--- a/match-zimmerman-site/index.html
+++ b/match-zimmerman-site/index.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Match Zimmerman Creative Media Group</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <nav>
+            <a href="#home" class="logo">MZCMG</a>
+            <ul>
+                <li><a href="#about">About</a></li>
+                <li><a href="#work">Studio Work</a></li>
+                <li><a href="#projects">Projects</a></li>
+                <li><a href="#blog">Blog</a></li>
+                <li><a href="#archive">Archive</a></li>
+                <li><a href="#consulting">Consulting</a></li>
+                <li><a href="#shop">Shop</a></li>
+                <li><a href="#contact">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <section id="home" class="hero">
+        <h1>Creative systems. Speculative futures. Hybrid minds.</h1>
+        <div class="marquee">
+            <div class="marquee-content">
+                <a href="#work"><img src="https://via.placeholder.com/200" alt="Work"></a>
+                <a href="#projects"><img src="https://via.placeholder.com/200" alt="R&D"></a>
+                <a href="#blog"><img src="https://via.placeholder.com/200" alt="Blog"></a>
+                <a href="#archive"><img src="https://via.placeholder.com/200" alt="Archive"></a>
+                <a href="#consulting"><img src="https://via.placeholder.com/200" alt="Consulting"></a>
+                <a href="#shop"><img src="https://via.placeholder.com/200" alt="Shop"></a>
+            </div>
+        </div>
+    </section>
+
+    <section id="about" class="content">
+        <h2>About</h2>
+        <p>Match Zimmerman Creative Media Group explores the intersection of art, technology, and culture. Our studio works with institutions and brands to craft future-driven narratives and visual systems.</p>
+        <p><strong>Credibility:</strong> Projects and exhibitions at MoMA, Tribeca Film Festival, and more.</p>
+    </section>
+
+    <section id="work" class="content">
+        <h2>Studio Work</h2>
+        <div class="grid">
+            <div class="card">Art direction project</div>
+            <div class="card">Animation project</div>
+            <div class="card">Branding project</div>
+            <div class="card">UX project</div>
+        </div>
+    </section>
+
+    <section id="projects" class="content">
+        <h2>Projects (R&amp;D)</h2>
+        <div class="grid">
+            <div class="card">Project: Magpie</div>
+            <div class="card">AI experiments</div>
+            <div class="card">Generative design tools</div>
+        </div>
+    </section>
+
+    <section id="blog" class="content">
+        <h2>Blog / Theory</h2>
+        <div class="grid">
+            <div class="card">Essay placeholder</div>
+            <div class="card">System theory note</div>
+            <div class="card">AI cognition article</div>
+        </div>
+    </section>
+
+    <section id="archive" class="content">
+        <h2>Archive</h2>
+        <div class="grid">
+            <div class="card">Gallery show</div>
+            <div class="card">Old experiment</div>
+            <div class="card">Early NFT</div>
+        </div>
+    </section>
+
+    <section id="consulting" class="content">
+        <h2>Consulting</h2>
+        <p>We provide strategic support for artists, educators, and institutions. Get in touch to discuss tailored workshops, digital transformation, and creative research partnerships.</p>
+    </section>
+
+    <section id="shop" class="content">
+        <h2>MZBRDZ Shop</h2>
+        <p>Conceptual merch and apparel coming soon. <a href="#">Sign up for updates</a>.</p>
+    </section>
+
+    <section id="contact" class="content contact">
+        <h2>Contact</h2>
+        <form>
+            <label>
+                Category
+                <select>
+                    <option>Studio</option>
+                    <option>Consulting</option>
+                    <option>Press</option>
+                    <option>Merch</option>
+                </select>
+            </label>
+            <label>
+                Your Email
+                <input type="email" required>
+            </label>
+            <label>
+                Message
+                <textarea required></textarea>
+            </label>
+            <button type="submit">Send</button>
+        </form>
+    </section>
+
+    <footer>
+        <p>&copy; 2024 Match Zimmerman Creative Media Group</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/match-zimmerman-site/script.js
+++ b/match-zimmerman-site/script.js
@@ -1,0 +1,6 @@
+// simple pause on hover for marquee
+const marquee = document.querySelector('.marquee-content');
+if (marquee) {
+    marquee.addEventListener('mouseover', () => marquee.style.animationPlayState = 'paused');
+    marquee.addEventListener('mouseout', () => marquee.style.animationPlayState = 'running');
+}

--- a/match-zimmerman-site/style.css
+++ b/match-zimmerman-site/style.css
@@ -1,0 +1,109 @@
+:root {
+    --accent: #ff5c5c;
+    --bg: #000;
+    --fg: #fff;
+}
+body {
+    margin: 0;
+    font-family: 'Inter', sans-serif;
+    color: var(--fg);
+    background: var(--bg);
+    line-height: 1.6;
+}
+header {
+    position: sticky;
+    top: 0;
+    background: var(--bg);
+    padding: 1rem;
+    z-index: 1000;
+    border-bottom: 1px solid var(--accent);
+}
+nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+nav ul {
+    list-style: none;
+    display: flex;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+}
+nav a {
+    color: var(--fg);
+    text-decoration: none;
+    font-weight: 700;
+}
+.logo {
+    font-weight: 700;
+    color: var(--accent);
+}
+.hero {
+    padding: 6rem 1rem;
+    text-align: center;
+}
+.hero h1 {
+    font-size: 2rem;
+    margin-bottom: 2rem;
+}
+.marquee {
+    overflow: hidden;
+    width: 100%;
+}
+.marquee-content {
+    display: flex;
+    gap: 1rem;
+    animation: scroll 20s linear infinite;
+}
+.marquee-content img {
+    width: 200px;
+    height: 200px;
+    object-fit: cover;
+    border: 2px solid var(--accent);
+}
+@keyframes scroll {
+    from { transform: translateX(0); }
+    to { transform: translateX(-50%); }
+}
+.content {
+    padding: 4rem 1rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 1rem;
+}
+.card {
+    background: #111;
+    border: 1px solid var(--accent);
+    padding: 1rem;
+    text-align: center;
+}
+.contact form {
+    display: grid;
+    gap: 1rem;
+}
+input, textarea, select, button {
+    padding: 0.5rem;
+    border: 1px solid var(--accent);
+    background: #111;
+    color: var(--fg);
+    width: 100%;
+}
+button {
+    background: var(--accent);
+    color: var(--bg);
+    cursor: pointer;
+    border: none;
+}
+footer {
+    text-align: center;
+    padding: 2rem 1rem;
+    border-top: 1px solid var(--accent);
+}
+@media (min-width: 768px) {
+    .hero h1 { font-size: 3rem; }
+}


### PR DESCRIPTION
## Summary
- create new `match-zimmerman-site` folder
- add single page layout with hero tagline and site sections
- implement minimal black & white grid design with accent color and marquee
- include small JS for hover pause on the marquee

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d7ed7b34883338b731b541a2cd3cc